### PR TITLE
Update markdown-it-anchor package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "loader-utils": "^1.1.0",
     "lodash.get": "^4.4.2",
     "markdown-it": "^8.4.1",
-    "markdown-it-anchor": "^4.0.0",
+    "markdown-it-anchor": "^5.0.2",
     "mini-css-extract-plugin": "^0.4.0",
     "native-toast": "^2.0.0",
     "p-limit": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4726,10 +4726,6 @@ markdown-it-anchor@^4.0.0:
   dependencies:
     string "^3.3.3"
 
-markdown-it-highlight-lines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-highlight-lines/-/markdown-it-highlight-lines-1.0.0.tgz#d6b56aca5ab9674cf140214f5591749e87ecbc39"
-
 markdown-it@^8.4.1:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.1.tgz#206fe59b0e4e1b78a7c73250af9b34a4ad0aaf44"


### PR DESCRIPTION
to use fix for high severity vulnerability